### PR TITLE
Fix name of parameter used in match queries

### DIFF
--- a/query_match.go
+++ b/query_match.go
@@ -62,19 +62,19 @@ func (q *MatchQuery) Map() map[string]interface{} {
 }
 
 type matchParams struct {
-	Qry          interface{}   `structs:"query"`
-	Anl          string        `structs:"analyzer,omitempty"`
-	AutoGenerate *bool         `structs:"auto_generate_synonyms_phrase_query,omitempty"`
-	Fuzz         string        `structs:"fuzziness,omitempty"`
-	MaxExp       uint16        `structs:"max_expansions,omitempty"`
-	PrefLen      uint16        `structs:"prefix_length,omitempty"`
-	Trans        *bool         `structs:"transpositions,omitempty"`
-	FuzzyRw      string        `structs:"fuzzy_rewrite,omitempty"`
-	Lent         bool          `structs:"lenient,omitempty"`
-	Op           MatchOperator `structs:"operator,string,omitempty"`
-	MinMatch     string        `structs:"minimum_should_match,omitempty"`
-	ZeroTerms    ZeroTerms     `structs:"zero_terms_query,string,omitempty"`
-	Slp          uint16        `structs:"slop,omitempty"` // only relevant for match_phrase query
+	Qry                 interface{}   `structs:"query"`
+	Anl                 string        `structs:"analyzer,omitempty"`
+	AutoGenerate        *bool         `structs:"auto_generate_synonyms_phrase_query,omitempty"`
+	Fuzz                string        `structs:"fuzziness,omitempty"`
+	MaxExp              uint16        `structs:"max_expansions,omitempty"`
+	PrefLen             uint16        `structs:"prefix_length,omitempty"`
+	FuzzyTranspositions *bool         `structs:"fuzzy_transpositions,omitempty"`
+	FuzzyRw             string        `structs:"fuzzy_rewrite,omitempty"`
+	Lent                bool          `structs:"lenient,omitempty"`
+	Op                  MatchOperator `structs:"operator,string,omitempty"`
+	MinMatch            string        `structs:"minimum_should_match,omitempty"`
+	ZeroTerms           ZeroTerms     `structs:"zero_terms_query,string,omitempty"`
+	Slp                 uint16        `structs:"slop,omitempty"` // only relevant for match_phrase query
 }
 
 // Match creates a new query of type "match" with the provided field name.
@@ -160,10 +160,10 @@ func (q *MatchQuery) PrefixLength(l uint16) *MatchQuery {
 	return q
 }
 
-// Transpositions sets whether edits for fuzzy matching include transpositions
+// FuzzyTranspositions sets whether edits for fuzzy matching include transpositions
 // of two adjacent characters.
-func (q *MatchQuery) Transpositions(b bool) *MatchQuery {
-	q.params.Trans = &b
+func (q *MatchQuery) FuzzyTranspositions(b bool) *MatchQuery {
+	q.params.FuzzyTranspositions = &b
 	return q
 }
 

--- a/query_match_test.go
+++ b/query_match_test.go
@@ -23,14 +23,14 @@ func TestMatch(t *testing.T) {
 		},
 		{
 			"match with more params",
-			Match("issue_number").Query(16).Transpositions(false).MaxExpansions(32).Operator(OperatorAnd),
+			Match("issue_number").Query(16).FuzzyTranspositions(false).MaxExpansions(32).Operator(OperatorAnd),
 			map[string]interface{}{
 				"match": map[string]interface{}{
 					"issue_number": map[string]interface{}{
-						"query":          16,
-						"max_expansions": 32,
-						"transpositions": false,
-						"operator":       "AND",
+						"query":                16,
+						"max_expansions":       32,
+						"fuzzy_transpositions": false,
+						"operator":             "AND",
 					},
 				},
 			},

--- a/query_multi_match.go
+++ b/query_multi_match.go
@@ -21,23 +21,23 @@ func (q *MultiMatchQuery) Map() map[string]interface{} {
 }
 
 type multiMatchParams struct {
-	Qry          interface{}    `structs:"query"`
-	Fields       []string       `structs:"fields"`
-	Type         MultiMatchType `structs:"type,string,omitempty"`
-	TieBrk       float32        `structs:"tie_breaker,omitempty"`
-	Boost        float32        `structs:"boost,omitempty"`
-	Anl          string         `structs:"analyzer,omitempty"`
-	AutoGenerate *bool          `structs:"auto_generate_synonyms_phrase_query,omitempty"`
-	Fuzz         string         `structs:"fuzziness,omitempty"`
-	MaxExp       uint16         `structs:"max_expansions,omitempty"`
-	PrefLen      uint16         `structs:"prefix_length,omitempty"`
-	Trans        *bool          `structs:"transpositions,omitempty"`
-	FuzzyRw      string         `structs:"fuzzy_rewrite,omitempty"`
-	Lent         *bool          `structs:"lenient,omitempty"`
-	Op           MatchOperator  `structs:"operator,string,omitempty"`
-	MinMatch     string         `structs:"minimum_should_match,omitempty"`
-	ZeroTerms    ZeroTerms      `structs:"zero_terms_query,string,omitempty"`
-	Slp          uint16         `structs:"slop,omitempty"`
+	Qry                 interface{}    `structs:"query"`
+	Fields              []string       `structs:"fields"`
+	Type                MultiMatchType `structs:"type,string,omitempty"`
+	TieBrk              float32        `structs:"tie_breaker,omitempty"`
+	Boost               float32        `structs:"boost,omitempty"`
+	Anl                 string         `structs:"analyzer,omitempty"`
+	AutoGenerate        *bool          `structs:"auto_generate_synonyms_phrase_query,omitempty"`
+	Fuzz                string         `structs:"fuzziness,omitempty"`
+	MaxExp              uint16         `structs:"max_expansions,omitempty"`
+	PrefLen             uint16         `structs:"prefix_length,omitempty"`
+	FuzzyTranspositions *bool          `structs:"fuzzy_transpositions,omitempty"`
+	FuzzyRw             string         `structs:"fuzzy_rewrite,omitempty"`
+	Lent                *bool          `structs:"lenient,omitempty"`
+	Op                  MatchOperator  `structs:"operator,string,omitempty"`
+	MinMatch            string         `structs:"minimum_should_match,omitempty"`
+	ZeroTerms           ZeroTerms      `structs:"zero_terms_query,string,omitempty"`
+	Slp                 uint16         `structs:"slop,omitempty"`
 }
 
 // MultiMatch creates a new query of type "multi_match"
@@ -116,10 +116,10 @@ func (q *MultiMatchQuery) Boost(l float32) *MultiMatchQuery {
 	return q
 }
 
-// Transpositions sets whether edits for fuzzy matching include transpositions
+// FuzzyTranspositions sets whether edits for fuzzy matching include transpositions
 // of two adjacent characters.
-func (q *MultiMatchQuery) Transpositions(b bool) *MultiMatchQuery {
-	q.params.Trans = &b
+func (q *MultiMatchQuery) FuzzyTranspositions(b bool) *MultiMatchQuery {
+	q.params.FuzzyTranspositions = &b
 	return q
 }
 

--- a/query_multi_match_test.go
+++ b/query_multi_match_test.go
@@ -32,7 +32,7 @@ func TestMultiMatch(t *testing.T) {
 				PrefixLength(12).
 				TieBreaker(0.3).
 				Boost(6.4).
-				Transpositions(true).
+				FuzzyTranspositions(true).
 				FuzzyRewrite("scoring_boolean").
 				Lenient(true).
 				Operator(OperatorAnd).
@@ -51,7 +51,7 @@ func TestMultiMatch(t *testing.T) {
 					"max_expansions":                      16,
 					"minimum_should_match":                "3<90%",
 					"prefix_length":                       12,
-					"transpositions":                      true,
+					"fuzzy_transpositions":                true,
 					"type":                                "phrase",
 					"tie_breaker":                         0.3,
 					"operator":                            "AND",


### PR DESCRIPTION
Thank you for maintaining this project.

The parameter is called `fuzzy_transpositions` in the context of match queries. Passing `transpositions` results in error. Please see https://opensearch.org/docs/latest/query-dsl/full-text/match/ and https://opensearch.org/docs/latest/query-dsl/full-text/multi-match/