### PR TITLE
feat: extend support for sort clauses

### DIFF
--- a/common.go
+++ b/common.go
@@ -22,17 +22,3 @@ func (source Source) Map() map[string]interface{} {
 	}
 	return m
 }
-
-// Sort represents a list of keys to sort by.
-type Sort []map[string]interface{}
-
-// Order is the ordering for a sort key (ascending, descending).
-type Order string
-
-const (
-	// OrderAsc represents sorting in ascending order.
-	OrderAsc Order = "asc"
-
-	// OrderDesc represents sorting in descending order.
-	OrderDesc Order = "desc"
-)

--- a/search_test.go
+++ b/search_test.go
@@ -57,8 +57,10 @@ func TestSearchMaps(t *testing.T) {
 				Size(30).
 				From(5).
 				Explain(true).
-				Sort("field_1", OrderDesc).
-				Sort("field_2", OrderAsc).
+				Sort(
+					FieldSort("field_1").Order(OrderDesc),
+					FieldSort("field_2").Order(OrderAsc),
+				).
 				SourceIncludes("field_1", "field_2").
 				SourceExcludes("field_3").
 				Timeout(time.Duration(20000000000)).

--- a/sort.go
+++ b/sort.go
@@ -1,0 +1,141 @@
+package osquery
+
+// Order is the ordering for a sort key (ascending, descending).
+type Order string
+
+const (
+	// OrderAsc represents sorting in ascending order.
+	OrderAsc Order = "asc"
+
+	// OrderDesc represents sorting in descending order.
+	OrderDesc Order = "desc"
+)
+
+// Mode is the mode for a sort key (min, max, sum, avg, median).
+type Mode string
+
+const (
+	// SortModeMin represents the minimum value.
+	SortModeMin Mode = "min"
+
+	// SortModeMax represents the maximum value.
+	SortModeMax Mode = "max"
+
+	// SortModeSum represents the sum of values.
+	SortModeSum Mode = "sum"
+
+	// SortModeAvg represents the average of values.
+	SortModeAvg Mode = "avg"
+
+	// SortModeMedian represents the median of values.
+	SortModeMedian Mode = "median"
+)
+
+// SortOption is an interface for different types of sort options
+type SortOption interface {
+	Map() map[string]any
+}
+
+// ScriptSortOption represents a script-based sort option for elasticsearch
+type ScriptSortOption struct {
+	sortType string
+	script   *ScriptField
+	order    Order
+}
+
+// ScriptSort creates a new query of type "_script" with the provided
+// type and script.
+func ScriptSort(scriptField *ScriptField, sortType string) *ScriptSortOption {
+	return &ScriptSortOption{
+		script:   scriptField,
+		sortType: sortType,
+	}
+}
+
+func (s *ScriptSortOption) Order(order Order) *ScriptSortOption {
+	s.order = order
+	return s
+}
+
+func (s *ScriptSortOption) Map() map[string]any {
+	scriptMapRaw, ok := s.script.Map()["script"]
+	if !ok {
+		return nil
+	}
+
+	scriptMap, ok := scriptMapRaw.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	sortOptions := map[string]any{
+		"type":   s.sortType,
+		"script": scriptMap,
+	}
+
+	if s.order != "" {
+		sortOptions["order"] = s.order
+	}
+
+	return map[string]any{
+		"_script": sortOptions,
+	}
+}
+
+type FieldSortOption struct {
+	field        string
+	order        Order
+	mode         Mode
+	nestedPath   string
+	nestedFilter Mappable
+}
+
+func FieldSort(field string) *FieldSortOption {
+	return &FieldSortOption{
+		field: field,
+	}
+}
+
+func (f *FieldSortOption) Order(order Order) *FieldSortOption {
+	f.order = order
+	return f
+}
+
+func (f *FieldSortOption) Mode(mode Mode) *FieldSortOption {
+	f.mode = mode
+	return f
+}
+
+func (f *FieldSortOption) NestedPath(nestedPath string) *FieldSortOption {
+	f.nestedPath = nestedPath
+	return f
+}
+
+func (f *FieldSortOption) NestedFilter(nestedFilter Mappable) *FieldSortOption {
+	f.nestedFilter = nestedFilter
+	return f
+}
+
+func (f *FieldSortOption) Map() map[string]any {
+	sortOptions := map[string]any{}
+
+	if f.order != "" {
+		sortOptions["order"] = f.order
+	}
+
+	if f.mode != "" {
+		sortOptions["mode"] = f.mode
+	}
+
+	if f.nestedPath != "" {
+		sortOptions["nested_path"] = f.nestedPath
+
+		if f.nestedFilter != nil {
+			sortOptions["nested_filter"] = f.nestedFilter.Map()
+		}
+	}
+
+	return map[string]any{
+		f.field: sortOptions,
+	}
+}

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,0 +1,257 @@
+// Package osquery modified by harshit98 on 2025-05-29
+// Changes: Added sort params support like order, mode, nested_path, nested_filter, script-based sort
+package osquery
+
+import (
+	"testing"
+)
+
+func TestSortExtensions(t *testing.T) {
+	fieldSortWithOrder := FieldSort("field").Order(OrderAsc)
+	fieldSortWithOrderAndMode := FieldSort("field").Order(OrderDesc).Mode(SortModeAvg)
+
+	nestedFieldSort := FieldSort("nested.field").Order(OrderAsc).NestedPath("nested")
+
+	nestedFieldSortWithFilter := FieldSort("nested.field").
+		Order(OrderAsc).
+		NestedPath("nested").
+		NestedFilter(Match("nested.type").Query("value"))
+
+	nestedFieldSortWithOrderAndMode := FieldSort("nested.field").
+		Order(OrderDesc).
+		Mode(SortModeMax).
+		NestedPath("nested").
+		NestedFilter(Match("nested.type").Query("value"))
+
+	multipleSort1 := FieldSort("field1").Order(OrderAsc)
+
+	multipleSort2 := FieldSort("nested.field").
+		Order(OrderDesc).
+		Mode(SortModeMin).
+		NestedPath("nested").
+		NestedFilter(Match("nested.type").Query("value"))
+
+	runMapTests(t, []mapTest{
+		{
+			"sort with basic order only",
+			Search().Sort(fieldSortWithOrder),
+			map[string]any{
+				"sort": []map[string]any{
+					{
+						"field": map[string]any{
+							"order": "asc",
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with mode",
+			Search().Sort(fieldSortWithOrderAndMode),
+			map[string]any{
+				"sort": []map[string]any{
+					{
+						"field": map[string]any{
+							"order": "desc",
+							"mode":  "avg",
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with nested_path",
+			Search().Sort(nestedFieldSort),
+			map[string]any{
+				"sort": []map[string]any{
+					{
+						"nested.field": map[string]any{
+							"order":       "asc",
+							"nested_path": "nested",
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with nested_path and nested_filter",
+			Search().Sort(nestedFieldSortWithFilter),
+			map[string]any{
+				"sort": []map[string]any{
+					{
+						"nested.field": map[string]any{
+							"order":       "asc",
+							"nested_path": "nested",
+							"nested_filter": map[string]any{
+								"match": map[string]any{
+									"nested.type": map[string]any{
+										"query": "value",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with mode, nested_path and nested_filter",
+			Search().Sort(nestedFieldSortWithOrderAndMode),
+			map[string]any{
+				"sort": []map[string]any{
+					{
+						"nested.field": map[string]any{
+							"order":       "desc",
+							"mode":        "max",
+							"nested_path": "nested",
+							"nested_filter": map[string]any{
+								"match": map[string]any{
+									"nested.type": map[string]any{
+										"query": "value",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"multiple sorts with different options",
+			Search().Sort(multipleSort1, multipleSort2),
+			map[string]any{
+				"sort": []map[string]any{
+					{
+						"field1": map[string]any{
+							"order": "asc",
+						},
+					},
+					{
+						"nested.field": map[string]any{
+							"order":       "desc",
+							"mode":        "min",
+							"nested_path": "nested",
+							"nested_filter": map[string]any{
+								"match": map[string]any{
+									"nested.type": map[string]any{
+										"query": "value",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestScriptSortExtensions(t *testing.T) {
+	// Create script fields for reuse
+	scriptFieldSort1 := Script("test_script").
+		Source("doc['field_name'].value").
+		Lang("painless")
+
+	scriptFieldSort2 := Script("test_script").
+		Source("doc['field_name'].value * params.factor").
+		Lang("painless").
+		Params(ScriptParams{"factor": 1.5})
+
+	scriptFieldSort3 := Script("test_script").
+		Source("if (doc['parent_obj.score_field'].size()!=0) { return ( Math.log(doc['parent_obj.score_field'].value*100 + 10 ) * _score ) } else { return _score }").
+		Lang("painless")
+
+	// Create script sort params for reuse
+	scriptSortParams1 := ScriptSort(scriptFieldSort1, "number").Order(OrderDesc)
+	scriptSortParams2 := ScriptSort(scriptFieldSort2, "number").Order(OrderAsc)
+	scriptSortParams3 := ScriptSort(scriptFieldSort3, "number").Order(OrderDesc)
+
+	docScoreFieldSort := FieldSort("_score")
+	regularFieldSort := FieldSort("regular_field").Order(OrderAsc)
+
+	runMapTests(t, []mapTest{
+		{
+			"sort with script",
+			Search().Sort(scriptSortParams1),
+			map[string]any{
+				"sort": []map[string]any{
+					{
+						"_script": map[string]any{
+							"type": "number",
+							"script": map[string]any{
+								"source": "doc['field_name'].value",
+								"lang":   "painless",
+							},
+							"order": "desc",
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with script and params",
+			Search().Sort(scriptSortParams2),
+			map[string]any{
+				"sort": []map[string]any{
+					{
+						"_script": map[string]any{
+							"type": "number",
+							"script": map[string]any{
+								"source": "doc['field_name'].value * params.factor",
+								"lang":   "painless",
+								"params": map[string]any{
+									"factor": 1.5,
+								},
+							},
+							"order": "asc",
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with raw field and script",
+			Search().Sort(docScoreFieldSort, scriptSortParams3),
+			map[string]any{
+				"sort": []any{
+					map[string]any{
+						"_score": map[string]any{},
+					},
+					map[string]any{
+						"_script": map[string]any{
+							"type": "number",
+							"script": map[string]any{
+								"source": "if (doc['parent_obj.score_field'].size()!=0) { return ( Math.log(doc['parent_obj.score_field'].value*100 + 10 ) * _score ) } else { return _score }",
+								"lang":   "painless",
+							},
+							"order": "desc",
+						},
+					},
+				},
+			},
+		},
+		{
+			"mixed sort with field and script",
+			Search().Sort(regularFieldSort, scriptSortParams1),
+			map[string]any{
+				"sort": []map[string]any{
+					{
+						"regular_field": map[string]any{
+							"order": "asc",
+						},
+					},
+					{
+						"_script": map[string]any{
+							"type": "number",
+							"script": map[string]any{
+								"source": "doc['field_name'].value",
+								"lang":   "painless",
+							},
+							"order": "desc",
+						},
+					},
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary
This PR adds advanced sort options to search requests in the osquery package, enabling usage of new features such as custom order, mode, nested path, nested filter, and script-based sorting. It also refactors the SearchRequest sorting API to accept multiple and more flexible sort options.

## Changelog

1. New `SortOption` interface and implementations:
    - Added `FieldSortOption` and `ScriptSortOption` types in the new `sort.go` file.
    - Supports for field sorts: 
         - order (asc/desc)
         - mode (min, max, sum, avg, median)
         - nested_path 
         - nested_filter
   - Supports script-based sorting, allowing scripts to define custom sort logic.

2. API changes in `SearchRequest`:
    - The sort field of `SearchRequest` is now []SortOption (previously a single Sort).
    - The `Sort()` method is updated to accept any number of `SortOption` arguments for greater flexibility.
    - The Map method now renders sort options according to their type.

3. Tests:
    - Added `sort_test.go` with comprehensive unit tests covering field and script sorts, combinations, mode, and nested filters.
    - Updated existing tests in `search_test.go` to use the new sorting API.