### PR TITLE
Support for _source.enabled: false in queries

### DIFF
--- a/common.go
+++ b/common.go
@@ -9,6 +9,7 @@ package osquery
 type Source struct {
 	includes []string
 	excludes []string
+	disabled bool
 }
 
 // Map returns a map representation of the Source object.
@@ -19,6 +20,9 @@ func (source Source) Map() map[string]interface{} {
 	}
 	if len(source.excludes) > 0 {
 		m["excludes"] = source.excludes
+	}
+	if source.disabled {
+		m["enabled"] = false
 	}
 	return m
 }

--- a/search.go
+++ b/search.go
@@ -103,6 +103,12 @@ func (req *SearchRequest) SourceExcludes(keys ...string) *SearchRequest {
 	return req
 }
 
+// DisableSource ensures no matching documents are returned
+func (req *SearchRequest) DisableSource() *SearchRequest {
+	req.source.disabled = true
+	return req
+}
+
 // Highlight sets a highlight for the request.
 func (req *SearchRequest) Highlight(highlight Mappable) *SearchRequest {
 	req.highlight = highlight

--- a/search_test.go
+++ b/search_test.go
@@ -19,13 +19,16 @@ func TestSearchMaps(t *testing.T) {
 			},
 		},
 		{
-			"a simple match_all query with a size and no aggs",
-			Search().Query(MatchAll()).Size(20),
+			"a simple match_all query with a size, no aggs and source disabled",
+			Search().Query(MatchAll()).Size(20).DisableSource(),
 			map[string]interface{}{
 				"query": map[string]interface{}{
 					"match_all": map[string]interface{}{},
 				},
 				"size": 20,
+				"_source": map[string]interface{}{
+					"enabled": false,
+				},
 			},
 		},
 		{


### PR DESCRIPTION
Currently both the include and exclude functionality of _source is available, but not disabling matching documents altogether, for example (as per https://docs.opensearch.org/latest/field-types/metadata-fields/source/):

```json
"_source": {
  enabled: false
}
```

This PR adds the above functionality to SearchRequest, and also adds a test. Note that this only changes the query if source should be disabled, since the default is for it to be enabled.