### PR TITLE
Feat terms name

### DIFF
--- a/aggs_histogram.go
+++ b/aggs_histogram.go
@@ -1,0 +1,71 @@
+package osquery
+
+type HistogramAggregation struct {
+	name        string
+	field       string
+	interval    float64
+	offset      *float64
+	minDocCount *int
+	aggs        []Aggregation
+}
+
+// HistogramAgg creates a new histogram aggregation.
+func HistogramAgg(name string, field string, interval float64) *HistogramAggregation {
+	return &HistogramAggregation{
+		name:     name,
+		field:    field,
+		interval: interval,
+	}
+}
+
+// Name returns the name of the aggregation.
+func (agg *HistogramAggregation) Name() string {
+	return agg.name
+}
+
+// Offset sets an optional offset value.
+func (agg *HistogramAggregation) Offset(offset float64) *HistogramAggregation {
+	agg.offset = &offset
+	return agg
+}
+
+// MinDocCount sets the optional minimum document count for buckets.
+func (agg *HistogramAggregation) MinDocCount(min int) *HistogramAggregation {
+	agg.minDocCount = &min
+	return agg
+}
+
+// Aggs sets sub-aggregations for the histogram buckets.
+func (agg *HistogramAggregation) Aggs(aggs ...Aggregation) *HistogramAggregation {
+	agg.aggs = aggs
+	return agg
+}
+
+// Map builds the OpenSearch aggregation map.
+func (agg *HistogramAggregation) Map() map[string]interface{} {
+	histogramMap := map[string]interface{}{
+		"field":    agg.field,
+		"interval": agg.interval,
+	}
+
+	if agg.offset != nil {
+		histogramMap["offset"] = *agg.offset
+	}
+	if agg.minDocCount != nil {
+		histogramMap["min_doc_count"] = *agg.minDocCount
+	}
+
+	outerMap := map[string]interface{}{
+		"histogram": histogramMap,
+	}
+
+	if len(agg.aggs) > 0 {
+		subAggs := make(map[string]map[string]interface{})
+		for _, sub := range agg.aggs {
+			subAggs[sub.Name()] = sub.Map()
+		}
+		outerMap["aggs"] = subAggs
+	}
+
+	return outerMap
+}

--- a/aggs_histogram_test.go
+++ b/aggs_histogram_test.go
@@ -1,0 +1,50 @@
+package osquery
+
+import "testing"
+
+func TestHistogramAggs(t *testing.T) {
+	runMapTests(t, []mapTest{
+		{
+			"histogram agg: basic",
+			HistogramAgg("hist", "price", 10),
+			map[string]interface{}{
+				"histogram": map[string]interface{}{
+					"field":    "price",
+					"interval": 10.0,
+				},
+			},
+		},
+		{
+			"histogram agg: with offset and min_doc_count",
+			HistogramAgg("hist", "price", 5).
+				Offset(2).
+				MinDocCount(1),
+			map[string]interface{}{
+				"histogram": map[string]interface{}{
+					"field":         "price",
+					"interval":      5.0,
+					"offset":        2.0,
+					"min_doc_count": 1,
+				},
+			},
+		},
+		{
+			"histogram agg: with sub-aggs",
+			HistogramAgg("hist", "price", 20).
+				Aggs(Avg("avg_price", "price")),
+			map[string]interface{}{
+				"histogram": map[string]interface{}{
+					"field":    "price",
+					"interval": 20.0,
+				},
+				"aggs": map[string]interface{}{
+					"avg_price": map[string]interface{}{
+						"avg": map[string]interface{}{
+							"field": "price",
+						},
+					},
+				},
+			},
+		},
+	})
+}

--- a/aggs_reverse_nested.go
+++ b/aggs_reverse_nested.go
@@ -1,0 +1,53 @@
+package osquery
+
+type ReverseNestedAggregation struct {
+	name string
+	path *string       // Optional
+	aggs []Aggregation // Optional sub-aggregations
+}
+
+// ReverseNestedAgg creates a new reverse_nested aggregation.
+func ReverseNestedAgg(name string) *ReverseNestedAggregation {
+	return &ReverseNestedAggregation{
+		name: name,
+	}
+}
+
+// Name returns the name of the aggregation.
+func (agg *ReverseNestedAggregation) Name() string {
+	return agg.name
+}
+
+// Path sets the optional reverse_nested path.
+func (agg *ReverseNestedAggregation) Path(p string) *ReverseNestedAggregation {
+	agg.path = &p
+	return agg
+}
+
+// Aggs sets optional sub-aggregations.
+func (agg *ReverseNestedAggregation) Aggs(aggs ...Aggregation) *ReverseNestedAggregation {
+	agg.aggs = aggs
+	return agg
+}
+
+// Map builds the OpenSearch aggregation map.
+func (agg *ReverseNestedAggregation) Map() map[string]interface{} {
+	reverseNestedBody := make(map[string]interface{})
+	if agg.path != nil {
+		reverseNestedBody["path"] = *agg.path
+	}
+
+	outerMap := map[string]interface{}{
+		"reverse_nested": reverseNestedBody,
+	}
+
+	if len(agg.aggs) > 0 {
+		subAggs := make(map[string]map[string]interface{})
+		for _, sub := range agg.aggs {
+			subAggs[sub.Name()] = sub.Map()
+		}
+		outerMap["aggs"] = subAggs
+	}
+
+	return outerMap
+}

--- a/aggs_reverse_nested_test.go
+++ b/aggs_reverse_nested_test.go
@@ -1,0 +1,39 @@
+package osquery
+
+import "testing"
+
+func TestReverseNestedAggs(t *testing.T) {
+	runMapTests(t, []mapTest{
+		{
+			"reverse_nested agg: basic",
+			ReverseNestedAgg("to_parent"),
+			map[string]interface{}{
+				"reverse_nested": map[string]interface{}{},
+			},
+		},
+		{
+			"reverse_nested agg: with path",
+			ReverseNestedAgg("to_root").Path("some.nested.path"),
+			map[string]interface{}{
+				"reverse_nested": map[string]interface{}{
+					"path": "some.nested.path",
+				},
+			},
+		},
+		{
+			"reverse_nested agg: with sub-aggregations",
+			ReverseNestedAgg("to_parent").
+				Aggs(Cardinality("product_count", "group_id")),
+			map[string]interface{}{
+				"reverse_nested": map[string]interface{}{},
+				"aggs": map[string]interface{}{
+					"product_count": map[string]interface{}{
+						"cardinality": map[string]interface{}{
+							"field": "group_id",
+						},
+					},
+				},
+			},
+		},
+	})
+}

--- a/collapse.go
+++ b/collapse.go
@@ -1,0 +1,20 @@
+package osquery
+
+type Collapse struct {
+	field string
+	Mappable
+}
+
+func NewCollapse(field string) *Collapse {
+	return &Collapse{
+		field: field,
+	}
+}
+
+func (c *Collapse) Map() map[string]interface{} {
+	outerMap := map[string]interface{}{
+		"field": c.field,
+	}
+
+	return outerMap
+}

--- a/collapse.go
+++ b/collapse.go
@@ -5,16 +5,18 @@ type Collapse struct {
 	Mappable
 }
 
-func NewCollapse(field string) *Collapse {
-	return &Collapse{
+func CollapseField(field string) Collapse {
+	return Collapse{
 		field: field,
 	}
 }
 
-func (c *Collapse) Map() map[string]interface{} {
-	outerMap := map[string]interface{}{
-		"field": c.field,
+func (c Collapse) Map() map[string]interface{} {
+	outerMap := make(map[string]interface{})
+	if c.field != "" {
+		outerMap = map[string]interface{}{
+			"field": c.field,
+		}
 	}
-
 	return outerMap
 }

--- a/collapse_test.go
+++ b/collapse_test.go
@@ -6,7 +6,7 @@ func TestCollapse(t *testing.T) {
 	runMapTests(t, []mapTest{
 		{
 			"Basic collapse testing",
-			NewCollapse("variant_group.group_id"),
+			CollapseField("variant_group.group_id"),
 			map[string]interface{}{
 				"field": "variant_group.group_id",
 			},

--- a/collapse_test.go
+++ b/collapse_test.go
@@ -1,0 +1,15 @@
+package osquery
+
+import "testing"
+
+func TestCollapse(t *testing.T) {
+	runMapTests(t, []mapTest{
+		{
+			"Basic collapse testing",
+			NewCollapse("variant_group.group_id"),
+			map[string]interface{}{
+				"field": "variant_group.group_id",
+			},
+		},
+	})
+}

--- a/common.go
+++ b/common.go
@@ -12,8 +12,8 @@ type Source struct {
 }
 
 // Map returns a map representation of the Source object.
-func (source Source) Map() map[string]interface{} {
-	m := make(map[string]interface{})
+func (source Source) Map() map[string]any {
+	m := make(map[string]any)
 	if len(source.includes) > 0 {
 		m["includes"] = source.includes
 	}
@@ -21,67 +21,4 @@ func (source Source) Map() map[string]interface{} {
 		m["excludes"] = source.excludes
 	}
 	return m
-}
-
-// Sort represents a list of SortParams for sorting purpose.
-type Sort []SortParams
-
-// Order is the ordering for a sort key (ascending, descending).
-type Order string
-
-const (
-	// OrderAsc represents sorting in ascending order.
-	OrderAsc Order = "asc"
-
-	// OrderDesc represents sorting in descending order.
-	OrderDesc Order = "desc"
-)
-
-// Mode is the mode for a sort key (min, max, sum, avg, median).
-type Mode string
-
-const (
-	// SortModeMin represents the minimum value.
-	SortModeMin Mode = "min"
-
-	// SortModeMax represents the maximum value.
-	SortModeMax Mode = "max"
-
-	// SortModeSum represents the sum of values.
-	SortModeSum Mode = "sum"
-
-	// SortModeAvg represents the average of values.
-	SortModeAvg Mode = "avg"
-
-	// SortModeMedian represents the median of values.
-	SortModeMedian Mode = "median"
-)
-
-type SortParams struct {
-	Field        string
-	Order        Order
-	Mode         Mode
-	NestedPath   string
-	NestedFilter Mappable
-}
-
-func (s SortParams) Map() map[string]interface{} {
-	sortOptions := map[string]interface{}{}
-
-	if s.Order != "" {
-		sortOptions["order"] = s.Order
-	}
-	if s.Mode != "" {
-		sortOptions["mode"] = s.Mode
-	}
-	if s.NestedPath != "" {
-		sortOptions["nested_path"] = s.NestedPath
-
-		if s.NestedFilter != nil {
-			sortOptions["nested_filter"] = s.NestedFilter.Map()
-		}
-	}
-	return map[string]interface{}{
-		s.Field: sortOptions,
-	}
 }

--- a/common.go
+++ b/common.go
@@ -23,8 +23,8 @@ func (source Source) Map() map[string]interface{} {
 	return m
 }
 
-// Sort represents a list of keys to sort by.
-type Sort []map[string]interface{}
+// Sort represents a list of SortParams for sorting purpose.
+type Sort []SortParams
 
 // Order is the ordering for a sort key (ascending, descending).
 type Order string
@@ -36,3 +36,50 @@ const (
 	// OrderDesc represents sorting in descending order.
 	OrderDesc Order = "desc"
 )
+
+// Mode is the mode for a sort key (min, max, sum, avg, median).
+type Mode string
+
+const (
+	// SortModeMin represents the minimum value.
+	SortModeMin Mode = "min"
+
+	// SortModeMax represents the maximum value.
+	SortModeMax Mode = "max"
+
+	// SortModeSum represents the sum of values.
+	SortModeSum Mode = "sum"
+
+	// SortModeAvg represents the average of values.
+	SortModeAvg Mode = "avg"
+
+	// SortModeMedian represents the median of values.
+	SortModeMedian Mode = "median"
+)
+
+type SortParams struct {
+	Field        string
+	Order        Order
+	Mode         Mode
+	NestedPath   string
+	NestedFilter Mappable
+}
+
+func (s SortParams) Map() map[string]interface{} {
+	sortOptions := map[string]interface{}{
+		"order": s.Order,
+	}
+	if s.Mode != "" {
+		sortOptions["mode"] = s.Mode
+	}
+	if s.NestedPath != "" {
+		sortOptions["nested_path"] = s.NestedPath
+
+		if s.NestedFilter != nil {
+			sortOptions["nested_filter"] = s.NestedFilter.Map()
+		}
+	}
+	return map[string]interface{}{
+		s.Field: sortOptions,
+	}
+}

--- a/common.go
+++ b/common.go
@@ -66,8 +66,10 @@ type SortParams struct {
 }
 
 func (s SortParams) Map() map[string]interface{} {
-	sortOptions := map[string]interface{}{
-		"order": s.Order,
+	sortOptions := map[string]interface{}{}
+
+	if s.Order != "" {
+		sortOptions["order"] = s.Order
 	}
 	if s.Mode != "" {
 		sortOptions["mode"] = s.Mode

--- a/function_score.go
+++ b/function_score.go
@@ -1,0 +1,155 @@
+// Package osquery Modified by harshit98 on 2025-05-10
+// Changes: Added function score support
+package osquery
+
+type FunctionScoreQuery struct {
+	query     Mappable
+	functions []Function
+	boostMode string
+	scoreMode string
+	maxBoost  *float32
+	minScore  *float32
+	boost     *float32
+}
+
+type Function interface {
+	Map() map[string]interface{}
+}
+
+type RandomScoreFunction struct {
+	seed  *int64
+	field string
+}
+
+type ScriptScoreFunction struct {
+	script *ScriptField
+}
+
+// Additional functions can be added as per usecase in future like:
+// - ScriptScoreFunction
+// - DecayFunction (with variants for geo, date, numeric)
+// - WeightFunction
+//
+// For ref: https://docs.opensearch.org/docs/latest/query-dsl/compound/function-score/
+
+func FunctionScore(query Mappable) *FunctionScoreQuery {
+	return &FunctionScoreQuery{query: query}
+}
+
+func (q *FunctionScoreQuery) Function(f Function) *FunctionScoreQuery {
+	q.functions = append(q.functions, f)
+	return q
+}
+
+func (q *FunctionScoreQuery) BoostMode(boostMode string) *FunctionScoreQuery {
+	q.boostMode = boostMode
+	return q
+}
+
+func (q *FunctionScoreQuery) ScoreMode(scoreMode string) *FunctionScoreQuery {
+	q.scoreMode = scoreMode
+	return q
+}
+
+func (q *FunctionScoreQuery) MaxBoost(maxBoost float32) *FunctionScoreQuery {
+	q.maxBoost = &maxBoost
+	return q
+}
+
+func (q *FunctionScoreQuery) MinScore(minScore float32) *FunctionScoreQuery {
+	q.minScore = &minScore
+	return q
+}
+
+func (q *FunctionScoreQuery) Boost(boost float32) *FunctionScoreQuery {
+	q.boost = &boost
+	return q
+}
+
+func (q *FunctionScoreQuery) Map() map[string]interface{} {
+	m := make(map[string]interface{})
+
+	if q.query != nil {
+		m["query"] = q.query.Map()
+	}
+
+	if len(q.functions) > 0 {
+		funcs := make([]map[string]interface{}, len(q.functions))
+		for i, f := range q.functions {
+			funcs[i] = f.Map()
+		}
+		m["functions"] = funcs
+	}
+
+	if q.boostMode != "" {
+		m["boost_mode"] = q.boostMode
+	}
+
+	if q.maxBoost != nil {
+		m["max_boost"] = *q.maxBoost
+	}
+
+	if q.scoreMode != "" {
+		m["score_mode"] = q.scoreMode
+	}
+
+	if q.minScore != nil {
+		m["min_score"] = *q.minScore
+	}
+
+	if q.boost != nil {
+		m["boost"] = *q.boost
+	}
+
+	return map[string]interface{}{
+		"function_score": m,
+	}
+}
+
+func RandomScore() *RandomScoreFunction {
+	return &RandomScoreFunction{}
+}
+
+func (f *RandomScoreFunction) Seed(seed int64) *RandomScoreFunction {
+	f.seed = &seed
+	return f
+}
+
+func (f *RandomScoreFunction) Field(field string) *RandomScoreFunction {
+	f.field = field
+	return f
+}
+
+func (f *RandomScoreFunction) Map() map[string]interface{} {
+	m := make(map[string]interface{})
+
+	if f.seed != nil {
+		m["seed"] = *f.seed
+	}
+
+	if f.field != "" {
+		m["field"] = f.field
+	}
+
+	return map[string]interface{}{
+		"random_score": m,
+	}
+}
+
+func FunctionScriptScore(script *ScriptField) *ScriptScoreFunction {
+	return &ScriptScoreFunction{script: script}
+}
+
+func (f *ScriptScoreFunction) Map() map[string]interface{} {
+	if f.script == nil {
+		return map[string]interface{}{
+			"script_score": map[string]interface{}{},
+		}
+	}
+	scriptMap := f.script.Map()["script"].(map[string]interface{})
+	return map[string]interface{}{
+		"script_score": map[string]interface{}{
+			"script": scriptMap,
+		},
+	}
+}

--- a/function_score_test.go
+++ b/function_score_test.go
@@ -1,0 +1,233 @@
+package osquery
+
+import (
+	"testing"
+)
+
+func TestFunctionScore(t *testing.T) {
+	runMapTests(t, []mapTest{
+		{
+			"function_score query with random_score function",
+			FunctionScore(Term("user", "kimchy")).
+				Function(RandomScore()),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"random_score": map[string]interface{}{},
+						},
+					},
+				},
+			},
+		},
+		{
+			"function_score query with random_score function and boost_mode",
+			FunctionScore(Term("user", "kimchy")).
+				Function(RandomScore()).
+				BoostMode("sum"),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"random_score": map[string]interface{}{},
+						},
+					},
+					"boost_mode": "sum",
+				},
+			},
+		},
+		{
+			"function_score query with random_score function with seed",
+			FunctionScore(Term("user", "kimchy")).
+				Function(RandomScore().Seed(42)),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"random_score": map[string]interface{}{
+								"seed": int64(42),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"function_score query with random_score function with field",
+			FunctionScore(Term("user", "kimchy")).
+				Function(RandomScore().Field("_seq_no")),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"random_score": map[string]interface{}{
+								"field": "_seq_no",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"function_score query with multiple functions",
+			FunctionScore(Term("user", "kimchy")).
+				Function(RandomScore()).
+				Function(RandomScore().Seed(123)),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"random_score": map[string]interface{}{},
+						},
+						{
+							"random_score": map[string]interface{}{
+								"seed": int64(123),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"function_score query with match_all query",
+			FunctionScore(MatchAll()).
+				Function(RandomScore()),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"match_all": map[string]interface{}{},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"random_score": map[string]interface{}{},
+						},
+					},
+				},
+			},
+		},
+		{
+			"function_score query with script_score function",
+			FunctionScore(Term("user", "kimchy")).
+				Function(FunctionScriptScore(Script("my_script").Source("doc['my_field'].value * 2.0"))),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"script_score": map[string]interface{}{
+								"script": map[string]interface{}{
+									"source": "doc['my_field'].value * 2.0",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"function_score query with script_score function with params",
+			FunctionScore(Term("user", "kimchy")).
+				Function(FunctionScriptScore(Script("my_script").
+					Source("doc['my_field'].value * params.factor").
+					Params(ScriptParams{"factor": 2.0}).
+					Lang("painless"))),
+			map[string]interface{}{
+				"function_score": map[string]interface{}{
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"functions": []map[string]interface{}{
+						{
+							"script_score": map[string]interface{}{
+								"script": map[string]interface{}{
+									"source": "doc['my_field'].value * params.factor",
+									"params": map[string]interface{}{
+										"factor": 2.0,
+									},
+									"lang": "painless",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestFunctionScoreWithQuery(t *testing.T) {
+	runMapTests(t, []mapTest{
+		{
+			"query with function_score",
+			Query(
+				FunctionScore(Term("user", "kimchy")).
+					Function(RandomScore()).
+					BoostMode("sum"),
+			),
+			map[string]interface{}{
+				"query": map[string]interface{}{
+					"function_score": map[string]interface{}{
+						"query": map[string]interface{}{
+							"term": map[string]interface{}{
+								"user": map[string]interface{}{
+									"value": "kimchy",
+								},
+							},
+						},
+						"functions": []map[string]interface{}{
+							{
+								"random_score": map[string]interface{}{},
+							},
+						},
+						"boost_mode": "sum",
+					},
+				},
+			},
+		},
+	})
+}

--- a/query_nested.go
+++ b/query_nested.go
@@ -1,4 +1,4 @@
-// Modified by bforbhartiii on 2025-02-24
+// Package osquery Modified by bforbhartiii on 2025-02-24
 // Changes: Added nested query support
 package osquery
 
@@ -7,19 +7,19 @@ import "github.com/fatih/structs"
 type ScoreModeType string
 
 const (
-	// Uses the average relevance score of all matching inner documents
+	// ScoreModeAvg Uses the average relevance score of all matching inner documents
 	ScoreModeAvg ScoreModeType = "avg"
 
-	// Assigns the highest relevance score from the matching inner documents to the parent.
+	// ScoreModeMax Assigns the highest relevance score from the matching inner documents to the parent.
 	ScoreModeMax ScoreModeType = "max"
 
-	// Assigns the lowest relevance score from the matching inner documents to the parent.
+	// ScoreModeMin Assigns the lowest relevance score from the matching inner documents to the parent.
 	ScoreModeMin ScoreModeType = "min"
 
-	// Sums the relevance scores of all matching inner documents.
+	// ScoreModeSum Sums the relevance scores of all matching inner documents.
 	ScoreModeSum ScoreModeType = "sum"
 
-	// Ignores the relevance scores of inner documents and assigns a score of 0 to the parent document.
+	// ScoreModeNone Ignores the relevance scores of inner documents and assigns a score of 0 to the parent document.
 	ScoreModeNone ScoreModeType = "none"
 )
 

--- a/query_nested.go
+++ b/query_nested.go
@@ -64,7 +64,7 @@ func (q *NestedQuery) Map() map[string]interface{} {
 		"nested": structs.Map(struct {
 			Path      string                 `structs:"path"`
 			Query     map[string]interface{} `structs:"query"`
-			Name      string                 `structs:"name,omitempty"`
+			Name      string                 `structs:"_name,omitempty"`
 			ScoreMode string                 `structs:"score_mode,omitempty"`
 			InnerHits map[string]interface{} `structs:"inner_hits,omitempty"`
 		}{q.path, q.query.Map(), q.name, q.scoreMode, q.innerHits}),

--- a/query_nested.go
+++ b/query_nested.go
@@ -1,0 +1,65 @@
+// Modified by bforbhartiii on 2025-02-24
+// Changes: Added nested query support
+package osquery
+
+import "github.com/fatih/structs"
+
+type ScoreModeType string
+
+const (
+	// Uses the average relevance score of all matching inner documents
+	ScoreModeAvg ScoreModeType = "avg"
+
+	// Assigns the highest relevance score from the matching inner documents to the parent.
+	ScoreModeMax ScoreModeType = "max"
+
+	// Assigns the lowest relevance score from the matching inner documents to the parent.
+	ScoreModeMin ScoreModeType = "min"
+
+	// Sums the relevance scores of all matching inner documents.
+	ScoreModeSum ScoreModeType = "sum"
+
+	// Ignores the relevance scores of inner documents and assigns a score of 0 to the parent document.
+	ScoreModeNone ScoreModeType = "none"
+)
+
+// NestedQuery represents a compound query of type "nested",
+// as described in https://opensearch.org/docs/latest/query-dsl/joining/nested/
+type NestedQuery struct {
+	path      string
+	query     Mappable
+	scoreMode string
+	innerHits map[string]interface{}
+}
+
+// Nested creates a new query of type "nested" with the provided path and query.
+func Nested(path string, query Mappable) *NestedQuery {
+	return &NestedQuery{
+		path:  path,
+		query: query,
+	}
+}
+
+// ScoreMode sets the score mode of the query.
+func (q *NestedQuery) ScoreMode(mode ScoreModeType) *NestedQuery {
+	q.scoreMode = string(mode)
+	return q
+}
+
+// InnerHits sets the inner_hits field of the query.
+func (q *NestedQuery) InnerHits(innerHits map[string]interface{}) *NestedQuery {
+	q.innerHits = innerHits
+	return q
+}
+
+// Map returns a map representation of the query, implementing the Mappable interface.
+func (q *NestedQuery) Map() map[string]interface{} {
+	return map[string]interface{}{
+		"nested": structs.Map(struct {
+			Path      string                 `structs:"path"`
+			Query     map[string]interface{} `structs:"query"`
+			ScoreMode string                 `structs:"score_mode,omitempty"`
+			InnerHits map[string]interface{} `structs:"inner_hits,omitempty"`
+		}{q.path, q.query.Map(), q.scoreMode, q.innerHits}),
+	}
+}

--- a/query_nested.go
+++ b/query_nested.go
@@ -28,6 +28,7 @@ const (
 type NestedQuery struct {
 	path      string
 	query     Mappable
+	name      string
 	scoreMode string
 	innerHits map[string]interface{}
 }
@@ -52,14 +53,20 @@ func (q *NestedQuery) InnerHits(innerHits map[string]interface{}) *NestedQuery {
 	return q
 }
 
+func (q *NestedQuery) Name(name string) *NestedQuery {
+	q.name = name
+	return q
+}
+
 // Map returns a map representation of the query, implementing the Mappable interface.
 func (q *NestedQuery) Map() map[string]interface{} {
 	return map[string]interface{}{
 		"nested": structs.Map(struct {
 			Path      string                 `structs:"path"`
 			Query     map[string]interface{} `structs:"query"`
+			Name      string                 `structs:"name,omitempty"`
 			ScoreMode string                 `structs:"score_mode,omitempty"`
 			InnerHits map[string]interface{} `structs:"inner_hits,omitempty"`
-		}{q.path, q.query.Map(), q.scoreMode, q.innerHits}),
+		}{q.path, q.query.Map(), q.name, q.scoreMode, q.innerHits}),
 	}
 }

--- a/query_nested_test.go
+++ b/query_nested_test.go
@@ -57,5 +57,22 @@ func TestNestedQuery(t *testing.T) {
 				},
 			},
 		},
+		{
+			"nested query with name",
+			Nested("comments", Term("user", "kimchy")).Name("nested_comments"),
+			map[string]interface{}{
+				"nested": map[string]interface{}{
+					"path": "comments",
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"name": "nested_comments",
+				},
+			},
+		},
 	})
 }

--- a/query_nested_test.go
+++ b/query_nested_test.go
@@ -1,0 +1,61 @@
+package osquery
+
+import "testing"
+
+// Test cases for NestedQuery
+func TestNestedQuery(t *testing.T) {
+	runMapTests(t, []mapTest{
+		{
+			"nested query without optional fields",
+			Nested("comments", Term("user", "kimchy")),
+			map[string]interface{}{
+				"nested": map[string]interface{}{
+					"path": "comments",
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"nested query with score_mode",
+			Nested("comments", Term("user", "kimchy")).ScoreMode(ScoreModeMax),
+			map[string]interface{}{
+				"nested": map[string]interface{}{
+					"path": "comments",
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"score_mode": "max",
+				},
+			},
+		},
+		{
+			"nested query with inner_hits",
+			Nested("comments", Term("user", "kimchy")).InnerHits(map[string]interface{}{"size": 3}),
+			map[string]interface{}{
+				"nested": map[string]interface{}{
+					"path": "comments",
+					"query": map[string]interface{}{
+						"term": map[string]interface{}{
+							"user": map[string]interface{}{
+								"value": "kimchy",
+							},
+						},
+					},
+					"inner_hits": map[string]interface{}{
+						"size": 3,
+					},
+				},
+			},
+		},
+	})
+}

--- a/query_script_score.go
+++ b/query_script_score.go
@@ -1,6 +1,5 @@
 // Modified by Sushmita on 2025-01-31
-// Changes: Updated ElasticSearch client to OpenSearch client, changed package name to 'osquery',
-// updated references to OpenSearch documentation, and modified examples accordingly.
+// Changes: Added script score query support
 
 package osquery
 

--- a/query_term_level.go
+++ b/query_term_level.go
@@ -448,6 +448,7 @@ type TermsQuery struct {
 	field  string
 	values []interface{}
 	boost  float32
+	name   string
 }
 
 // Terms creates a new query of type "terms" on the provided field, and
@@ -465,6 +466,12 @@ func (q *TermsQuery) Values(values ...interface{}) *TermsQuery {
 	return q
 }
 
+// Name sets the name for the query.
+func (q *TermsQuery) Name(name string) *TermsQuery {
+	q.name = name
+	return q
+}
+
 // Boost sets the boost value of the query.
 func (q *TermsQuery) Boost(b float32) *TermsQuery {
 	q.boost = b
@@ -477,6 +484,9 @@ func (q TermsQuery) Map() map[string]interface{} {
 	innerMap := map[string]interface{}{q.field: q.values}
 	if q.boost > 0 {
 		innerMap["boost"] = q.boost
+	}
+	if q.name != "" {
+		innerMap["_name"] = q.name
 	}
 
 	return map[string]interface{}{"terms": innerMap}

--- a/query_term_level_test.go
+++ b/query_term_level_test.go
@@ -141,6 +141,17 @@ func TestTermLevel(t *testing.T) {
 			},
 		},
 		{
+			"terms",
+			Terms("user").Values("bla", "pl").Boost(1.3).Name("test"),
+			map[string]interface{}{
+				"terms": map[string]interface{}{
+					"user":  []string{"bla", "pl"},
+					"boost": 1.3,
+					"_name": "test",
+				},
+			},
+		},
+		{
 			"terms_set",
 			TermsSet("programming_languages", "go", "rust", "COBOL").MinimumShouldMatchField("required_matches"),
 			map[string]interface{}{

--- a/search.go
+++ b/search.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"time"
 
-	opensearch "github.com/opensearch-project/opensearch-go/v4"
-	opensearchapi "github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+	"github.com/opensearch-project/opensearch-go/v4"
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 )
 
 // SearchRequest represents the parameters for an OpenSearch query.
@@ -64,13 +64,8 @@ func (req *SearchRequest) Size(size uint64) *SearchRequest {
 }
 
 // Sort sets how the results should be sorted.
-func (req *SearchRequest) Sort(name string, order Order) *SearchRequest {
-	req.sort = append(req.sort, map[string]interface{}{
-		name: map[string]interface{}{
-			"order": order,
-		},
-	})
-
+func (req *SearchRequest) Sort(params SortParams) *SearchRequest {
+	req.sort = append(req.sort, params)
 	return req
 }
 
@@ -136,7 +131,11 @@ func (req *SearchRequest) Map() map[string]interface{} {
 		m["size"] = *req.size
 	}
 	if len(req.sort) > 0 {
-		m["sort"] = req.sort
+		sortMaps := make([]map[string]interface{}, 0, len(req.sort))
+		for _, params := range req.sort {
+			sortMaps = append(sortMaps, params.Map())
+		}
+		m["sort"] = sortMaps
 	}
 	if req.from != nil {
 		m["from"] = *req.from

--- a/search.go
+++ b/search.go
@@ -72,12 +72,6 @@ func (req *SearchRequest) Sort(opts ...SortOption) *SearchRequest {
 	return req
 }
 
-// SortScript is a convenience method for script-based sorting
-func (req *SearchRequest) SortScript(params ScriptSortParams) *SearchRequest {
-	req.sort = append(req.sort, &params)
-	return req
-}
-
 // SearchAfter retrieve the sorted result
 func (req *SearchRequest) SearchAfter(s ...interface{}) *SearchRequest {
 	req.searchAfter = append(req.searchAfter, s...)

--- a/search.go
+++ b/search.go
@@ -64,8 +64,8 @@ func (req *SearchRequest) Size(size uint64) *SearchRequest {
 }
 
 // Sort sets how the results should be sorted.
-func (req *SearchRequest) Sort(params SortParams) *SearchRequest {
-	req.sort = append(req.sort, params)
+func (req *SearchRequest) Sort(params ...SortParams) *SearchRequest {
+	req.sort = params
 	return req
 }
 

--- a/search.go
+++ b/search.go
@@ -20,6 +20,7 @@ type SearchRequest struct {
 	searchAfter  []interface{}
 	postFilter   Mappable
 	query        Mappable
+	collapse     *Collapse
 	size         *uint64
 	sort         []SortOption
 	source       Source
@@ -60,6 +61,12 @@ func (req *SearchRequest) From(offset uint64) *SearchRequest {
 // documentation - is 10.
 func (req *SearchRequest) Size(size uint64) *SearchRequest {
 	req.size = &size
+	return req
+}
+
+// Collapse sets field collapsing for the request.
+func (req *SearchRequest) Collapse(collapse *Collapse) *SearchRequest {
+	req.collapse = collapse
 	return req
 }
 
@@ -132,6 +139,11 @@ func (req *SearchRequest) Map() map[string]interface{} {
 	}
 	if req.size != nil {
 		m["size"] = *req.size
+	}
+	if req.collapse != nil {
+		collapse := make(map[string]interface{})
+		collapse = req.collapse.Map()
+		m["collapse"] = collapse
 	}
 	if len(req.sort) > 0 {
 		sortSlice := make([]any, 0, len(req.sort))

--- a/search.go
+++ b/search.go
@@ -20,7 +20,7 @@ type SearchRequest struct {
 	searchAfter  []interface{}
 	postFilter   Mappable
 	query        Mappable
-	collapse     *Collapse
+	collapse     Collapse
 	size         *uint64
 	sort         []SortOption
 	source       Source
@@ -65,7 +65,7 @@ func (req *SearchRequest) Size(size uint64) *SearchRequest {
 }
 
 // Collapse sets field collapsing for the request.
-func (req *SearchRequest) Collapse(collapse *Collapse) *SearchRequest {
+func (req *SearchRequest) Collapse(collapse Collapse) *SearchRequest {
 	req.collapse = collapse
 	return req
 }
@@ -140,11 +140,12 @@ func (req *SearchRequest) Map() map[string]interface{} {
 	if req.size != nil {
 		m["size"] = *req.size
 	}
-	if req.collapse != nil {
-		collapse := make(map[string]interface{})
-		collapse = req.collapse.Map()
+
+	collapse := req.collapse.Map()
+	if len(collapse) > 0 {
 		m["collapse"] = collapse
 	}
+
 	if len(req.sort) > 0 {
 		sortSlice := make([]any, 0, len(req.sort))
 		for _, params := range req.sort {

--- a/search_test.go
+++ b/search_test.go
@@ -57,8 +57,8 @@ func TestSearchMaps(t *testing.T) {
 				Size(30).
 				From(5).
 				Explain(true).
-				Sort(SortParams{Field: "field_1", Order: OrderDesc}).
-				Sort(SortParams{Field: "field_2", Order: OrderAsc}).
+				Sort(Field("field_1").Order(OrderDesc)).
+				Sort(Field("field_2").Order(OrderAsc)).
 				SourceIncludes("field_1", "field_2").
 				SourceExcludes("field_3").
 				Timeout(time.Duration(20000000000)).

--- a/search_test.go
+++ b/search_test.go
@@ -57,8 +57,10 @@ func TestSearchMaps(t *testing.T) {
 				Size(30).
 				From(5).
 				Explain(true).
-				Sort(Field("field_1").Order(OrderDesc)).
-				Sort(Field("field_2").Order(OrderAsc)).
+				Sort(
+					FieldSort("field_1").Order(OrderDesc),
+					FieldSort("field_2").Order(OrderAsc),
+				).
 				SourceIncludes("field_1", "field_2").
 				SourceExcludes("field_3").
 				Timeout(time.Duration(20000000000)).

--- a/search_test.go
+++ b/search_test.go
@@ -57,8 +57,8 @@ func TestSearchMaps(t *testing.T) {
 				Size(30).
 				From(5).
 				Explain(true).
-				Sort("field_1", OrderDesc).
-				Sort("field_2", OrderAsc).
+				Sort(SortParams{Field: "field_1", Order: OrderDesc}).
+				Sort(SortParams{Field: "field_2", Order: OrderAsc}).
 				SourceIncludes("field_1", "field_2").
 				SourceExcludes("field_3").
 				Timeout(time.Duration(20000000000)).

--- a/search_test.go
+++ b/search_test.go
@@ -153,7 +153,7 @@ func TestSearchMaps(t *testing.T) {
 		},
 		{
 			"a search with collapse",
-			Search().Collapse(NewCollapse("variant_group.group_id")),
+			Search().Collapse(CollapseField("variant_group.group_id")),
 			map[string]interface{}{
 				"collapse": map[string]interface{}{
 					"field": "variant_group.group_id",

--- a/search_test.go
+++ b/search_test.go
@@ -151,5 +151,14 @@ func TestSearchMaps(t *testing.T) {
 				},
 			},
 		},
+		{
+			"a search with collapse",
+			Search().Collapse(NewCollapse("variant_group.group_id")),
+			map[string]interface{}{
+				"collapse": map[string]interface{}{
+					"field": "variant_group.group_id",
+				},
+			},
+		},
 	})
 }

--- a/sort.go
+++ b/sort.go
@@ -36,8 +36,8 @@ type SortOption interface {
 	Map() map[string]any
 }
 
-// ScriptSortParams represents a script-based sort option for elasticsearch
-type ScriptSortParams struct {
+// ScriptSortOption represents a script-based sort option for elasticsearch
+type ScriptSortOption struct {
 	sortType string
 	script   *ScriptField
 	order    Order
@@ -45,19 +45,19 @@ type ScriptSortParams struct {
 
 // ScriptSort creates a new query of type "_script" with the provided
 // type and script.
-func ScriptSort(scriptField *ScriptField, sortType string) *ScriptSortParams {
-	return &ScriptSortParams{
+func ScriptSort(scriptField *ScriptField, sortType string) *ScriptSortOption {
+	return &ScriptSortOption{
 		script:   scriptField,
 		sortType: sortType,
 	}
 }
 
-func (s *ScriptSortParams) Order(order Order) *ScriptSortParams {
+func (s *ScriptSortOption) Order(order Order) *ScriptSortOption {
 	s.order = order
 	return s
 }
 
-func (s *ScriptSortParams) Map() map[string]any {
+func (s *ScriptSortOption) Map() map[string]any {
 	scriptMapRaw, ok := s.script.Map()["script"]
 	if !ok {
 		return nil
@@ -82,7 +82,7 @@ func (s *ScriptSortParams) Map() map[string]any {
 	}
 }
 
-type SortParams struct {
+type FieldSortOption struct {
 	field        string
 	order        Order
 	mode         Mode
@@ -90,49 +90,52 @@ type SortParams struct {
 	nestedFilter Mappable
 }
 
-func Field(field string) *SortParams {
-	return &SortParams{
+func FieldSort(field string) *FieldSortOption {
+	return &FieldSortOption{
 		field: field,
 	}
 }
 
-func (s *SortParams) Order(order Order) *SortParams {
-	s.order = order
-	return s
+func (f *FieldSortOption) Order(order Order) *FieldSortOption {
+	f.order = order
+	return f
 }
 
-func (s *SortParams) Mode(mode Mode) *SortParams {
-	s.mode = mode
-	return s
+func (f *FieldSortOption) Mode(mode Mode) *FieldSortOption {
+	f.mode = mode
+	return f
 }
 
-func (s *SortParams) NestedPath(nestedPath string) *SortParams {
-	s.nestedPath = nestedPath
-	return s
+func (f *FieldSortOption) NestedPath(nestedPath string) *FieldSortOption {
+	f.nestedPath = nestedPath
+	return f
 }
 
-func (s *SortParams) NestedFilter(nestedFilter Mappable) *SortParams {
-	s.nestedFilter = nestedFilter
-	return s
+func (f *FieldSortOption) NestedFilter(nestedFilter Mappable) *FieldSortOption {
+	f.nestedFilter = nestedFilter
+	return f
 }
 
-func (s *SortParams) Map() map[string]any {
+func (f *FieldSortOption) Map() map[string]any {
 	sortOptions := map[string]any{}
 
-	if s.order != "" {
-		sortOptions["order"] = s.order
+	if f.order != "" {
+		sortOptions["order"] = f.order
 	}
-	if s.mode != "" {
-		sortOptions["mode"] = s.mode
-	}
-	if s.nestedPath != "" {
-		sortOptions["nested_path"] = s.nestedPath
 
-		if s.nestedFilter != nil {
-			sortOptions["nested_filter"] = s.nestedFilter.Map()
+	if f.mode != "" {
+		sortOptions["mode"] = f.mode
+	}
+
+	if f.nestedPath != "" {
+		sortOptions["nested_path"] = f.nestedPath
+
+		if f.nestedFilter != nil {
+			sortOptions["nested_filter"] = f.nestedFilter.Map()
 		}
 	}
+
 	return map[string]any{
-		s.field: sortOptions,
+		f.field: sortOptions,
 	}
 }

--- a/sort.go
+++ b/sort.go
@@ -1,0 +1,138 @@
+package osquery
+
+// Order is the ordering for a sort key (ascending, descending).
+type Order string
+
+const (
+	// OrderAsc represents sorting in ascending order.
+	OrderAsc Order = "asc"
+
+	// OrderDesc represents sorting in descending order.
+	OrderDesc Order = "desc"
+)
+
+// Mode is the mode for a sort key (min, max, sum, avg, median).
+type Mode string
+
+const (
+	// SortModeMin represents the minimum value.
+	SortModeMin Mode = "min"
+
+	// SortModeMax represents the maximum value.
+	SortModeMax Mode = "max"
+
+	// SortModeSum represents the sum of values.
+	SortModeSum Mode = "sum"
+
+	// SortModeAvg represents the average of values.
+	SortModeAvg Mode = "avg"
+
+	// SortModeMedian represents the median of values.
+	SortModeMedian Mode = "median"
+)
+
+// SortOption is an interface for different types of sort options
+type SortOption interface {
+	Map() map[string]any
+}
+
+// ScriptSortParams represents a script-based sort option for elasticsearch
+type ScriptSortParams struct {
+	sortType string
+	script   *ScriptField
+	order    Order
+}
+
+// ScriptSort creates a new query of type "_script" with the provided
+// type and script.
+func ScriptSort(scriptField *ScriptField, sortType string) *ScriptSortParams {
+	return &ScriptSortParams{
+		script:   scriptField,
+		sortType: sortType,
+	}
+}
+
+func (s *ScriptSortParams) Order(order Order) *ScriptSortParams {
+	s.order = order
+	return s
+}
+
+func (s *ScriptSortParams) Map() map[string]any {
+	scriptMapRaw, ok := s.script.Map()["script"]
+	if !ok {
+		return nil
+	}
+
+	scriptMap, ok := scriptMapRaw.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	sortOptions := map[string]any{
+		"type":   s.sortType,
+		"script": scriptMap,
+	}
+
+	if s.order != "" {
+		sortOptions["order"] = s.order
+	}
+
+	return map[string]any{
+		"_script": sortOptions,
+	}
+}
+
+type SortParams struct {
+	field        string
+	order        Order
+	mode         Mode
+	nestedPath   string
+	nestedFilter Mappable
+}
+
+func Field(field string) *SortParams {
+	return &SortParams{
+		field: field,
+	}
+}
+
+func (s *SortParams) Order(order Order) *SortParams {
+	s.order = order
+	return s
+}
+
+func (s *SortParams) Mode(mode Mode) *SortParams {
+	s.mode = mode
+	return s
+}
+
+func (s *SortParams) NestedPath(nestedPath string) *SortParams {
+	s.nestedPath = nestedPath
+	return s
+}
+
+func (s *SortParams) NestedFilter(nestedFilter Mappable) *SortParams {
+	s.nestedFilter = nestedFilter
+	return s
+}
+
+func (s *SortParams) Map() map[string]any {
+	sortOptions := map[string]any{}
+
+	if s.order != "" {
+		sortOptions["order"] = s.order
+	}
+	if s.mode != "" {
+		sortOptions["mode"] = s.mode
+	}
+	if s.nestedPath != "" {
+		sortOptions["nested_path"] = s.nestedPath
+
+		if s.nestedFilter != nil {
+			sortOptions["nested_filter"] = s.nestedFilter.Map()
+		}
+	}
+	return map[string]any{
+		s.field: sortOptions,
+	}
+}

--- a/sort_test.go
+++ b/sort_test.go
@@ -10,11 +10,11 @@ func TestSortExtensions(t *testing.T) {
 	runMapTests(t, []mapTest{
 		{
 			"sort with basic order only",
-			Search().Sort(SortParams{Field: "field", Order: OrderAsc}),
-			map[string]interface{}{
-				"sort": []map[string]interface{}{
+			Search().Sort(Field("field").Order(OrderAsc)),
+			map[string]any{
+				"sort": []map[string]any{
 					{
-						"field": map[string]interface{}{
+						"field": map[string]any{
 							"order": "asc",
 						},
 					},
@@ -23,11 +23,11 @@ func TestSortExtensions(t *testing.T) {
 		},
 		{
 			"sort with mode",
-			Search().Sort(SortParams{Field: "field", Order: OrderDesc, Mode: SortModeAvg}),
-			map[string]interface{}{
-				"sort": []map[string]interface{}{
+			Search().Sort(Field("field").Order(OrderDesc).Mode(SortModeAvg)),
+			map[string]any{
+				"sort": []map[string]any{
 					{
-						"field": map[string]interface{}{
+						"field": map[string]any{
 							"order": "desc",
 							"mode":  "avg",
 						},
@@ -37,11 +37,11 @@ func TestSortExtensions(t *testing.T) {
 		},
 		{
 			"sort with nested_path",
-			Search().Sort(SortParams{Field: "nested.field", Order: OrderAsc, NestedPath: "nested"}),
-			map[string]interface{}{
-				"sort": []map[string]interface{}{
+			Search().Sort(Field("nested.field").Order(OrderAsc).NestedPath("nested")),
+			map[string]any{
+				"sort": []map[string]any{
 					{
-						"nested.field": map[string]interface{}{
+						"nested.field": map[string]any{
 							"order":       "asc",
 							"nested_path": "nested",
 						},
@@ -51,21 +51,21 @@ func TestSortExtensions(t *testing.T) {
 		},
 		{
 			"sort with nested_path and nested_filter",
-			Search().Sort(SortParams{
-				Field:        "nested.field",
-				Order:        OrderAsc,
-				NestedPath:   "nested",
-				NestedFilter: Match("nested.type").Query("value"),
-			}),
-			map[string]interface{}{
-				"sort": []map[string]interface{}{
+			Search().Sort(
+				Field("nested.field").
+					Order(OrderAsc).
+					NestedPath("nested").
+					NestedFilter(Match("nested.type").Query("value")),
+			),
+			map[string]any{
+				"sort": []map[string]any{
 					{
-						"nested.field": map[string]interface{}{
+						"nested.field": map[string]any{
 							"order":       "asc",
 							"nested_path": "nested",
-							"nested_filter": map[string]interface{}{
-								"match": map[string]interface{}{
-									"nested.type": map[string]interface{}{
+							"nested_filter": map[string]any{
+								"match": map[string]any{
+									"nested.type": map[string]any{
 										"query": "value",
 									},
 								},
@@ -77,23 +77,23 @@ func TestSortExtensions(t *testing.T) {
 		},
 		{
 			"sort with mode, nested_path and nested_filter",
-			Search().Sort(SortParams{
-				Field:        "nested.field",
-				Order:        OrderDesc,
-				Mode:         SortModeMax,
-				NestedPath:   "nested",
-				NestedFilter: Match("nested.type").Query("value"),
-			}),
-			map[string]interface{}{
-				"sort": []map[string]interface{}{
+			Search().Sort(
+				Field("nested.field").
+					Order(OrderDesc).
+					Mode(SortModeMax).
+					NestedPath("nested").
+					NestedFilter(Match("nested.type").Query("value")),
+			),
+			map[string]any{
+				"sort": []map[string]any{
 					{
-						"nested.field": map[string]interface{}{
+						"nested.field": map[string]any{
 							"order":       "desc",
 							"mode":        "max",
 							"nested_path": "nested",
-							"nested_filter": map[string]interface{}{
-								"match": map[string]interface{}{
-									"nested.type": map[string]interface{}{
+							"nested_filter": map[string]any{
+								"match": map[string]any{
+									"nested.type": map[string]any{
 										"query": "value",
 									},
 								},
@@ -106,33 +106,144 @@ func TestSortExtensions(t *testing.T) {
 		{
 			"multiple sorts with different options",
 			Search().
-				Sort(SortParams{Field: "field1", Order: OrderAsc}).
-				Sort(SortParams{
-					Field:        "nested.field",
-					Order:        OrderDesc,
-					Mode:         SortModeMin,
-					NestedPath:   "nested",
-					NestedFilter: Match("nested.type").Query("value"),
-				}),
-			map[string]interface{}{
-				"sort": []map[string]interface{}{
+				Sort(Field("field1").Order(OrderAsc)).
+				Sort(
+					Field("nested.field").
+						Order(OrderDesc).
+						Mode(SortModeMin).
+						NestedPath("nested").
+						NestedFilter(Match("nested.type").Query("value")),
+				),
+			map[string]any{
+				"sort": []map[string]any{
 					{
-						"field1": map[string]interface{}{
+						"field1": map[string]any{
 							"order": "asc",
 						},
 					},
 					{
-						"nested.field": map[string]interface{}{
+						"nested.field": map[string]any{
 							"order":       "desc",
 							"mode":        "min",
 							"nested_path": "nested",
-							"nested_filter": map[string]interface{}{
-								"match": map[string]interface{}{
-									"nested.type": map[string]interface{}{
+							"nested_filter": map[string]any{
+								"match": map[string]any{
+									"nested.type": map[string]any{
 										"query": "value",
 									},
 								},
 							},
+						},
+					},
+				},
+			},
+		},
+	})
+}
+
+func TestScriptSortExtensions(t *testing.T) {
+	// Create script fields for reuse
+	scriptField1 := Script("test_script").
+		Source("doc['field_name'].value").
+		Lang("painless")
+
+	scriptField2 := Script("test_script").
+		Source("doc['field_name'].value * params.factor").
+		Lang("painless").
+		Params(ScriptParams{"factor": 1.5})
+
+	scriptField3 := Script("test_script").
+		Source("if (doc['parent_obj.score_field'].size()!=0) { return ( Math.log(doc['parent_obj.score_field'].value*100 + 10 ) * _score ) } else { return _score }").
+		Lang("painless")
+
+	// Create script sort params for reuse
+	scriptSortParams1 := ScriptSort(scriptField1, "number").Order(OrderDesc)
+	scriptSortParams2 := ScriptSort(scriptField2, "number").Order(OrderAsc)
+	scriptSortParams3 := ScriptSort(scriptField3, "number").Order(OrderDesc)
+
+	runMapTests(t, []mapTest{
+		{
+			"sort with script",
+			Search().SortScript(*scriptSortParams1),
+			map[string]any{
+				"sort": []map[string]any{
+					{
+						"_script": map[string]any{
+							"type": "number",
+							"script": map[string]any{
+								"source": "doc['field_name'].value",
+								"lang":   "painless",
+							},
+							"order": "desc",
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with script and params",
+			Search().SortScript(*scriptSortParams2),
+			map[string]any{
+				"sort": []map[string]any{
+					{
+						"_script": map[string]any{
+							"type": "number",
+							"script": map[string]any{
+								"source": "doc['field_name'].value * params.factor",
+								"lang":   "painless",
+								"params": map[string]any{
+									"factor": 1.5,
+								},
+							},
+							"order": "asc",
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with raw field and script",
+			Search().
+				Sort(Field("_score")).
+				SortScript(*scriptSortParams3),
+			map[string]any{
+				"sort": []any{
+					map[string]any{
+						"_score": map[string]any{},
+					},
+					map[string]any{
+						"_script": map[string]any{
+							"type": "number",
+							"script": map[string]any{
+								"source": "if (doc['parent_obj.score_field'].size()!=0) { return ( Math.log(doc['parent_obj.score_field'].value*100 + 10 ) * _score ) } else { return _score }",
+								"lang":   "painless",
+							},
+							"order": "desc",
+						},
+					},
+				},
+			},
+		},
+		{
+			"mixed sort with field and script",
+			Search().
+				Sort(Field("regular_field").Order(OrderAsc)).
+				SortScript(*scriptSortParams1),
+			map[string]any{
+				"sort": []map[string]any{
+					{
+						"regular_field": map[string]any{
+							"order": "asc",
+						},
+					},
+					{
+						"_script": map[string]any{
+							"type": "number",
+							"script": map[string]any{
+								"source": "doc['field_name'].value",
+								"lang":   "painless",
+							},
+							"order": "desc",
 						},
 					},
 				},

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,0 +1,141 @@
+// Package osquery provides a query builder for OpenSearch.
+package osquery
+
+import (
+	"testing"
+)
+
+func TestSortExtensions(t *testing.T) {
+	runMapTests(t, []mapTest{
+		{
+			"sort with basic order only",
+			Search().Sort(SortParams{Field: "field", Order: OrderAsc}),
+			map[string]interface{}{
+				"sort": []map[string]interface{}{
+					{
+						"field": map[string]interface{}{
+							"order": "asc",
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with mode",
+			Search().Sort(SortParams{Field: "field", Order: OrderDesc, Mode: SortModeAvg}),
+			map[string]interface{}{
+				"sort": []map[string]interface{}{
+					{
+						"field": map[string]interface{}{
+							"order": "desc",
+							"mode":  "avg",
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with nested_path",
+			Search().Sort(SortParams{Field: "nested.field", Order: OrderAsc, NestedPath: "nested"}),
+			map[string]interface{}{
+				"sort": []map[string]interface{}{
+					{
+						"nested.field": map[string]interface{}{
+							"order":       "asc",
+							"nested_path": "nested",
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with nested_path and nested_filter",
+			Search().Sort(SortParams{
+				Field:        "nested.field",
+				Order:        OrderAsc,
+				NestedPath:   "nested",
+				NestedFilter: Match("nested.type").Query("value"),
+			}),
+			map[string]interface{}{
+				"sort": []map[string]interface{}{
+					{
+						"nested.field": map[string]interface{}{
+							"order":       "asc",
+							"nested_path": "nested",
+							"nested_filter": map[string]interface{}{
+								"match": map[string]interface{}{
+									"nested.type": map[string]interface{}{
+										"query": "value",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"sort with mode, nested_path and nested_filter",
+			Search().Sort(SortParams{
+				Field:        "nested.field",
+				Order:        OrderDesc,
+				Mode:         SortModeMax,
+				NestedPath:   "nested",
+				NestedFilter: Match("nested.type").Query("value"),
+			}),
+			map[string]interface{}{
+				"sort": []map[string]interface{}{
+					{
+						"nested.field": map[string]interface{}{
+							"order":       "desc",
+							"mode":        "max",
+							"nested_path": "nested",
+							"nested_filter": map[string]interface{}{
+								"match": map[string]interface{}{
+									"nested.type": map[string]interface{}{
+										"query": "value",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			"multiple sorts with different options",
+			Search().
+				Sort(SortParams{Field: "field1", Order: OrderAsc}).
+				Sort(SortParams{
+					Field:        "nested.field",
+					Order:        OrderDesc,
+					Mode:         SortModeMin,
+					NestedPath:   "nested",
+					NestedFilter: Match("nested.type").Query("value"),
+				}),
+			map[string]interface{}{
+				"sort": []map[string]interface{}{
+					{
+						"field1": map[string]interface{}{
+							"order": "asc",
+						},
+					},
+					{
+						"nested.field": map[string]interface{}{
+							"order":       "desc",
+							"mode":        "min",
+							"nested_path": "nested",
+							"nested_filter": map[string]interface{}{
+								"match": map[string]interface{}{
+									"nested.type": map[string]interface{}{
+										"query": "value",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+}

--- a/sort_test.go
+++ b/sort_test.go
@@ -1,4 +1,5 @@
-// Package osquery provides a query builder for OpenSearch.
+// Package osquery Modified by harshit98 on 2025-05-07
+// Changes: Added sort params support like mode, nested_path, nested_filter
 package osquery
 
 import (


### PR DESCRIPTION
This pull request introduces several new features and enhancements to the OpenSearch query builder, including support for histogram and reverse_nested aggregations, function score queries, nested queries, and field collapsing. It also adds tests for each new feature to ensure correctness and reliability. Additionally, minor improvements were made to existing query types for consistency.

### New Aggregation and Query Features

* Added `HistogramAggregation` and `ReverseNestedAggregation` types, allowing users to build histogram and reverse_nested aggregations with support for sub-aggregations and optional parameters. (`aggs_histogram.go`, `aggs_reverse_nested.go`) [[1]](diffhunk://#diff-872023c8b757ad6123d1a51da6936fb3d59d6d73f1af65f294ed0d92241f8dacR1-R71) [[2]](diffhunk://#diff-2473b7d85e2a32626bfc4d10cf0e82ff926594024b3feef154d5cc2387d10578R1-R53)
* Introduced `FunctionScoreQuery` with support for random_score and script_score functions, including chaining for boost modes and other parameters. (`function_score.go`)
* Implemented `NestedQuery` type, supporting score modes, inner_hits, and named queries for nested document queries. (`query_nested.go`)
* Added `Collapse` type for field collapsing in search results. (`collapse.go`)

### Test Coverage

* Added comprehensive unit tests for histogram, reverse_nested, function_score, nested, and collapse features to verify their map outputs. (`aggs_histogram_test.go`, `aggs_reverse_nested_test.go`, `function_score_test.go`, `query_nested_test.go`, `collapse_test.go`) [[1]](diffhunk://#diff-0235dc1b3ae2567954d8bddd685dfe944714002106955ba6b9d0bdd27a2ffa21R1-R50) [[2]](diffhunk://#diff-016899d5903c90536f899bef6ccf3edb963cc8279eda48f350570b56a11174ebR1-R39) [[3]](diffhunk://#diff-11211ad021568a3b6d09981415226718fdcd1f7dac58f9a4384a0dc855cfb788R1-R233) [[4]](diffhunk://#diff-60da93b2e311043adb7ef375c3389800a92ef9972fca36e2197fe93dfe0c24b2R1-R78) [[5]](diffhunk://#diff-bd11d2895ed8c6442b60a87617421035c7e278040efbc440f6d00d6a08703b9aR1-R15)

### Minor Improvements

* Enhanced `TermsQuery` to support named queries by adding a `name` field and corresponding setter, with output in the query map. (`query_term_level.go`) [[1]](diffhunk://#diff-f8d74252902c2b79b82b63ea487f993d7d86aecfcccd3e6bfded4a141ab86504R451) [[2]](diffhunk://#diff-f8d74252902c2b79b82b63ea487f993d7d86aecfcccd3e6bfded4a141ab86504R469-R474) [[3]](diffhunk://#diff-f8d74252902c2b79b82b63ea487f993d7d86aecfcccd3e6bfded4a141ab86504R488-R490)
* Updated `Source.Map()` to use `any` instead of `interface{}` for improved Go type consistency, and removed unused sort/order types. (`common.go`) [[1]](diffhunk://#diff-f414a6ec09d90228aa7bafc117eaddd89d204ece70f1ee674027aa393ed63939L15-R16) [[2]](diffhunk://#diff-f414a6ec09d90228aa7bafc117eaddd89d204ece70f1ee674027aa393ed63939L25-L38)
* Added documentation and comments to new and modified files for clarity. (`query_nested.go`, `function_score.go`, `query_script_score.go`) [[1]](diffhunk://#diff-fb79797301158ad30c37e65cc59394304a982c6ad942a0053d52d6218c2204faR1-R72) [[2]](diffhunk://#diff-3d221d2287e08130355ebccc2cb9b3951e513255c61240f894dda2389fd506b1R1-R155) [[3]](diffhunk://#diff-ea915ad9c63ae3ff702a898bdf41faa6fc16cca229ab11f6f140a68c40c916a6L2-R2)